### PR TITLE
Feat : 가맹점 로그아웃 / Refresh Token을 통한 Access 재발급 기능 추가

### DIFF
--- a/backoffice-manage/build.gradle
+++ b/backoffice-manage/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
     // Swagger (SpringDoc OpenAPI 3)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/backoffice-manage/settings.gradle
+++ b/backoffice-manage/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'backoffice-manage'

--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/config/SwaggerConfig.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/config/SwaggerConfig.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,19 +13,26 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI customOpenAPI() {
-        final String securitySchemeName = "bearerAuth";
+        final String accessSchemeName = "bearerAuth";
+        final String refreshSchemeName = "refreshAuth";
 
         return new OpenAPI()
                 .info(new Info().title("Merchant API")
                         .description("가맹점 인증 및 관리 API 문서")
                         .version("v1.0"))
-                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
-                .components(new io.swagger.v3.oas.models.Components()
-                        .addSecuritySchemes(securitySchemeName,
+                .addSecurityItem(new SecurityRequirement().addList(accessSchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(accessSchemeName,
                                 new SecurityScheme()
-                                        .name(securitySchemeName)
+                                        .name("Authorization")
                                         .type(SecurityScheme.Type.HTTP)
                                         .scheme("bearer")
-                                        .bearerFormat("JWT")));
+                                        .bearerFormat("JWT"))
+                        .addSecuritySchemes(refreshSchemeName,
+                                new SecurityScheme()
+                                        .name("Refresh-Token")
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .description("리프레시 토큰 헤더")));
     }
 }

--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/dto/signup/SignupRequest.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/dto/signup/SignupRequest.java
@@ -3,10 +3,12 @@ package com.fastcampus.backofficemanage.dto.signup;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@SuperBuilder
 public abstract class SignupRequest {
     private String loginId;
     private String loginPw;

--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/dto/signup/request/MerchantSignUpRequest.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/dto/signup/request/MerchantSignUpRequest.java
@@ -2,14 +2,14 @@ package com.fastcampus.backofficemanage.dto.signup.request;
 
 import com.fastcampus.backofficemanage.dto.signup.SignupRequest;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 public class MerchantSignUpRequest extends SignupRequest {
 
     private String name;

--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/security/JwtProvider.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/security/JwtProvider.java
@@ -7,10 +7,12 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
 
 import java.security.Key;
 import java.util.Date;
 
+@Slf4j
 @Component
 public class JwtProvider {
 
@@ -30,6 +32,7 @@ public class JwtProvider {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (Exception e) {
+            log.warn("JWT 검증 실패: {}", e.getMessage());
             return false;
         }
     }
@@ -61,5 +64,16 @@ public class JwtProvider {
                 .setExpiration(new Date(now + validity))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public long getRemainingExpiration(String accessToken) {
+        Date expiration = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody()
+                .getExpiration();
+
+        return expiration.getTime() - System.currentTimeMillis();
     }
 }

--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/security/SecurityConfig.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.fastcampus.backofficemanage.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +16,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -24,6 +26,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/merchants/register",
                                 "/merchants/login",
+                                "/merchants/reissue",
+                                "/merchants/logout",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",
@@ -32,12 +36,11 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, redisTemplate), // ✅ 수정
                         org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
-
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {

--- a/backoffice-manage/src/main/resources/application.yml
+++ b/backoffice-manage/src/main/resources/application.yml
@@ -11,6 +11,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 server:
   port: 8081

--- a/backoffice-manage/src/test/java/com/fastcampus/backofficemanage/service/AuthServiceTest.java
+++ b/backoffice-manage/src/test/java/com/fastcampus/backofficemanage/service/AuthServiceTest.java
@@ -1,0 +1,103 @@
+package com.fastcampus.backofficemanage.service;
+
+import com.fastcampus.backofficemanage.dto.login.request.MerchantLoginRequest;
+import com.fastcampus.backofficemanage.dto.login.response.MerchantLoginResponse;
+import com.fastcampus.backofficemanage.dto.signup.request.MerchantSignUpRequest;
+import com.fastcampus.backofficemanage.dto.signup.response.MerchantSignUpResponse;
+import com.fastcampus.backofficemanage.entity.Merchant;
+import com.fastcampus.backofficemanage.repository.MerchantRepository;
+import com.fastcampus.backofficemanage.security.JwtProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+class AuthServiceTest {
+
+    @Mock
+    private MerchantRepository merchantRepository;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    void setUp() {
+        closeable = openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    void signup_shouldSucceed_whenValidRequest() {
+        // given
+        MerchantSignUpRequest request = MerchantSignUpRequest.builder()
+                .loginId("merchant123")
+                .loginPw("pw123")
+                .name("가맹점")
+                .businessNumber("123-456")
+                .contactName("홍길동")
+                .contactEmail("email@test.com")
+                .contactPhone("010-1234-5678")
+                .build();
+
+        given(merchantRepository.existsByLoginId("merchant123")).willReturn(false);
+        given(passwordEncoder.encode("pw123")).willReturn("encodedPw");
+        given(merchantRepository.save(any(Merchant.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        MerchantSignUpResponse response = authService.signup(request);
+
+        // then
+        assertEquals("merchant123", response.getLoginId());
+        assertEquals("가맹점", response.getName());
+        assertEquals("ACTIVE", response.getStatus());
+    }
+
+    @Test
+    void login_shouldReturnTokens_whenValidCredentials() {
+        // given
+        Merchant merchant = Merchant.builder()
+                .loginId("merchant123")
+                .loginPw("encodedPw")
+                .status("ACTIVE")
+                .build();
+
+        given(merchantRepository.findByLoginId("merchant123"))
+                .willReturn(Optional.of(merchant));
+        given(passwordEncoder.matches("pw123", "encodedPw")).willReturn(true);
+        given(jwtProvider.generateAccessToken("merchant123")).willReturn("access-token");
+        given(jwtProvider.generateRefreshToken("merchant123")).willReturn("refresh-token");
+
+        // when
+        MerchantLoginResponse response = authService.login(
+                MerchantLoginRequest.builder()
+                        .loginId("merchant123")
+                        .loginPw("pw123")
+                        .build()
+        );
+
+        // then
+        assertEquals("access-token", response.getAccessToken());
+        assertEquals("refresh-token", response.getRefreshToken());
+    }
+}


### PR DESCRIPTION
# 요약
> 로그아웃, Access Token 재발급 기능을 추가했고, 우선 Swagger를 통해 검사했습니다.
> 전 PR과 마찬가지로, 연휴 기간이기 때문에 리뷰어는 따로 지목하지는 않으려 합니다.

# 변경사항
> 가맹점 모듈에 한해 의존성에 Redis를 추가했습니다.
> 기능들을 위한 코드 변경이 있었습니다.

# 테스트 요소
> 둘 다 Swagger를 통한 테스트를 진행했고, 둘 다 성공적으로 확인 후 Push했습니다.
![image](https://github.com/user-attachments/assets/26c0b022-eab1-4f65-b3bb-1a0c57778c91)
