### PR TITLE
payment-infra entity 추가

### DIFF
--- a/payment-infra/build.gradle
+++ b/payment-infra/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/CardInfo.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/CardInfo.java
@@ -1,0 +1,31 @@
+package com.fastcampus.paymentinfra.infra.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Data
+public class CardInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long cardInfoId;
+
+    private Long userId;
+    private String type;
+    private String token;
+    private String last4;
+    private String cardCompany;
+
+    @CreationTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+}

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/CommonEntity.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/CommonEntity.java
@@ -1,0 +1,4 @@
+package com.fastcampus.paymentinfra.infra.entity;
+
+public class CommonEntity {
+}

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/Keys.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/Keys.java
@@ -1,0 +1,28 @@
+package com.fastcampus.paymentinfra.infra.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Data
+public class Keys {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long keysId;
+
+    private String encryptedKey;
+    private Long merchantId;
+
+    @CreationTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+}

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/Merchant.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/Merchant.java
@@ -1,0 +1,34 @@
+package com.fastcampus.paymentinfra.infra.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Data
+public class Merchant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long merchantId;
+
+    private String loginId;
+    private String loginPw;
+    private String name;
+    private String businessNumber;
+    private String contactName;
+    private String contactEmail;
+    private String contactPhone;
+    private String status;
+
+    @CreationTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+}

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/Payment.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/Payment.java
@@ -1,0 +1,39 @@
+package com.fastcampus.paymentinfra.infra.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Data
+public class Payment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long paymentId;
+
+    private Long transactionId;
+    private Long userId;
+    private Long paymentMethod;
+    private String paymentStatus;
+    private Long paidAmount;
+
+    @CreationTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime approvedAt;
+
+    private String failReason;
+    private Long lastTransactionId;
+
+    @CreationTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+}

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/PaymentMethod.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/PaymentMethod.java
@@ -1,0 +1,28 @@
+package com.fastcampus.paymentinfra.infra.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Data
+public class PaymentMethod {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long paymentMethodId;
+
+    private String type;
+
+    @CreationTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+}

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/Transaction.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/Transaction.java
@@ -1,0 +1,34 @@
+package com.fastcampus.paymentinfra.infra.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Data
+public class Transaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long transactionId;
+
+    private Long merchantId;
+    private String merchantOrderId;
+    private Long amount;
+    private String status;
+
+    @CreationTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime expireAt;
+
+    @CreationTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+}

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/Users.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/infra/entity/Users.java
@@ -1,0 +1,30 @@
+package com.fastcampus.paymentinfra.infra.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Data
+public class Users {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    private String name;
+    private String phone;
+    private String email;
+    private String simplePassword;
+
+    @CreationTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
# 요약
infra 모듈에 entity 들을 추가했습니다.
infra 모듈에 jpa 의존성을 추가했습니다

# 변경사항
build.gradle 에 jpa 의존성을 추가했습니다
현재 erd cloud 에 있는 table 들을 jpa entity 들로 구현해두었습니다.
기능을 분리하려면 entity 나 repository 같은 jpa 기능들을 infra 에 두는 게 맞는 것 같아서 옮겨둡니다
core 에서는 infra 모듈로부터 import 해서 쓰도록 하겠습니다
필요하시면 수정해주셔도 돼요!
혹시 충돌 있으면 말씀주세요~

# 테스트 요소

