### PR TITLE
Feat : Backoffice AOP + Testcode 추가

### DIFF
--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/aspect/CurrentLoginId.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/aspect/CurrentLoginId.java
@@ -1,0 +1,9 @@
+package com.fastcampus.backofficemanage.aspect;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentLoginId {
+}

--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/aspect/LoginIdResolver.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/aspect/LoginIdResolver.java
@@ -1,0 +1,35 @@
+package com.fastcampus.backofficemanage.aspect;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginIdResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentLoginId.class)
+                && parameter.getParameterType().equals(String.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new IllegalStateException("인증 정보가 존재하지 않습니다.");
+        }
+
+        return authentication.getPrincipal().toString();
+    }
+}

--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/aspect/WebConfig.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/aspect/WebConfig.java
@@ -1,0 +1,22 @@
+package com.fastcampus.backofficemanage.aspect;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginIdResolver loginIdResolver;
+
+    public WebConfig(LoginIdResolver loginIdResolver) {
+        this.loginIdResolver = loginIdResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginIdResolver);
+    }
+}

--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/config/TimeConfig.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/config/TimeConfig.java
@@ -1,0 +1,20 @@
+package com.fastcampus.backofficemanage.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class TimeConfig {
+
+    @Value("${app.timezone:Asia/Seoul}")
+    private String zone;
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of(zone));
+    }
+}

--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/dto/common/CommonResponse.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/dto/common/CommonResponse.java
@@ -12,4 +12,11 @@ import lombok.NoArgsConstructor;
 public class CommonResponse {
     private boolean success;
     private String message;
+
+    public static CommonResponse success(String message) {
+        return CommonResponse.builder()
+                .success(true)
+                .message(message)
+                .build();
+    }
 }

--- a/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/service/MerchantService.java
+++ b/backoffice-manage/src/main/java/com/fastcampus/backofficemanage/service/MerchantService.java
@@ -8,12 +8,12 @@ import com.fastcampus.backofficemanage.repository.MerchantRepository;
 import com.fastcampus.common.exception.code.MerchantErrorCode;
 import com.fastcampus.common.exception.exception.DuplicateKeyException;
 import com.fastcampus.common.exception.exception.NotFoundException;
-import com.fastcampus.common.util.AppClock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 @Service
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 public class MerchantService {
 
     private final MerchantRepository merchantRepository;
+    private final Clock clock;
 
     @Transactional(readOnly = true)
     public MerchantInfoResponse getMyInfo(String loginId) {
@@ -49,7 +50,7 @@ public class MerchantService {
                 request.getContactEmail(),
                 request.getContactPhone()
         );
-        merchant.setUpdatedAt(LocalDateTime.now(AppClock.CLOCK));
+        merchant.setUpdatedAt(LocalDateTime.now(clock));
 
         try {
             merchantRepository.flush(); // unique 제약조건 위반 감지용
@@ -69,7 +70,7 @@ public class MerchantService {
                 .orElseThrow(() -> new NotFoundException(MerchantErrorCode.NOT_FOUND));
 
         merchant.setStatus("DELETED");
-        merchant.setUpdatedAt(LocalDateTime.now(AppClock.CLOCK));
+        merchant.setUpdatedAt(LocalDateTime.now(clock));
 
         return CommonResponse.builder()
                 .success(true)

--- a/backoffice-manage/src/main/resources/application.yml
+++ b/backoffice-manage/src/main/resources/application.yml
@@ -21,6 +21,9 @@ spring:
 jwt:
   secret: dYVzdC1zZWNyZXQta2V5LXlvdS2jYW4tY2hhbmdlPXRoaXM=
 
+app:
+  timezone: Asia/Seoul
+
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/backoffice-manage/src/test/java/com/fastcampus/backofficemanage/service/AuthServiceTest.java
+++ b/backoffice-manage/src/test/java/com/fastcampus/backofficemanage/service/AuthServiceTest.java
@@ -7,9 +7,10 @@ import com.fastcampus.backofficemanage.dto.signup.response.MerchantSignUpRespons
 import com.fastcampus.backofficemanage.entity.Merchant;
 import com.fastcampus.backofficemanage.repository.MerchantRepository;
 import com.fastcampus.backofficemanage.security.JwtProvider;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import com.fastcampus.common.exception.exception.DuplicateKeyException;
+import com.fastcampus.common.exception.exception.NotFoundException;
+import com.fastcampus.common.exception.exception.UnauthorizedException;
+import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -20,21 +21,20 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+@DisplayName("AuthService 유닛 테스트")
 class AuthServiceTest {
 
-    @Mock
-    private MerchantRepository merchantRepository;
+    @Mock private MerchantRepository merchantRepository;
+    @Mock private BCryptPasswordEncoder passwordEncoder;
+    @Mock private JwtProvider jwtProvider;
 
-    @Mock
-    private BCryptPasswordEncoder passwordEncoder;
-
-    @Mock
-    private JwtProvider jwtProvider;
-
-    @InjectMocks
-    private AuthService authService;
+    @InjectMocks private AuthService authService;
 
     private AutoCloseable closeable;
+
+    private static final String LOGIN_ID = "merchant123";
+    private static final String RAW_PW = "pw123";
+    private static final String ENCODED_PW = "encodedPw";
 
     @BeforeEach
     void setUp() {
@@ -46,58 +46,118 @@ class AuthServiceTest {
         closeable.close();
     }
 
-    @Test
-    void signup_shouldSucceed_whenValidRequest() {
-        // given
-        MerchantSignUpRequest request = MerchantSignUpRequest.builder()
-                .loginId("merchant123")
-                .loginPw("pw123")
+    @Nested
+    @DisplayName("회원가입 (signup)")
+    class SignupTests {
+
+        @Test
+        @DisplayName("정상 회원가입 시 응답 DTO가 반환된다")
+        void givenValidSignupRequest_whenSignup_thenReturnsResponse() {
+            // given
+            MerchantSignUpRequest request = createSignupRequest();
+            given(merchantRepository.existsByLoginId(LOGIN_ID)).willReturn(false);
+            given(passwordEncoder.encode(RAW_PW)).willReturn(ENCODED_PW);
+            given(merchantRepository.save(any(Merchant.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            MerchantSignUpResponse response = authService.signup(request);
+
+            // then
+            assertEquals(LOGIN_ID, response.getLoginId());
+            assertEquals("가맹점", response.getName());
+            assertEquals("ACTIVE", response.getStatus());
+        }
+
+        @Test
+        @DisplayName("중복된 loginId로 회원가입 시 DuplicateKeyException이 발생한다")
+        void givenDuplicateLoginId_whenSignup_thenThrowsException() {
+            // given
+            MerchantSignUpRequest request = createSignupRequest();
+            given(merchantRepository.existsByLoginId(LOGIN_ID)).willReturn(true);
+
+            // expect
+            assertThrows(DuplicateKeyException.class, () -> authService.signup(request));
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 (login)")
+    class LoginTests {
+
+        @Test
+        @DisplayName("유효한 로그인 정보로 로그인 시 토큰이 반환된다")
+        void givenValidLoginCredentials_whenLogin_thenReturnsTokens() {
+            // given
+            Merchant merchant = createMerchant(LOGIN_ID, ENCODED_PW);
+            given(merchantRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(merchant));
+            given(passwordEncoder.matches(RAW_PW, ENCODED_PW)).willReturn(true);
+            given(jwtProvider.generateAccessToken(LOGIN_ID)).willReturn("access-token");
+            given(jwtProvider.generateRefreshToken(LOGIN_ID)).willReturn("refresh-token");
+
+            MerchantLoginRequest request = MerchantLoginRequest.builder()
+                    .loginId(LOGIN_ID)
+                    .loginPw(RAW_PW)
+                    .build();
+
+            // when
+            MerchantLoginResponse response = authService.login(request);
+
+            // then
+            assertEquals("access-token", response.getAccessToken());
+            assertEquals("refresh-token", response.getRefreshToken());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 loginId로 로그인 시 NotFoundException이 발생한다")
+        void givenInvalidLoginId_whenLogin_thenThrowsNotFoundException() {
+            // given
+            MerchantLoginRequest request = MerchantLoginRequest.builder()
+                    .loginId("wrongId")
+                    .loginPw(RAW_PW)
+                    .build();
+            given(merchantRepository.findByLoginId("wrongId")).willReturn(Optional.empty());
+
+            // expect
+            assertThrows(NotFoundException.class, () -> authService.login(request));
+        }
+
+        @Test
+        @DisplayName("비밀번호가 틀린 경우 UnauthorizedException이 발생한다")
+        void givenInvalidPassword_whenLogin_thenThrowsUnauthorizedException() {
+            // given
+            Merchant merchant = createMerchant(LOGIN_ID, ENCODED_PW);
+            given(merchantRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(merchant));
+            given(passwordEncoder.matches("wrongPw", ENCODED_PW)).willReturn(false);
+
+            MerchantLoginRequest request = MerchantLoginRequest.builder()
+                    .loginId(LOGIN_ID)
+                    .loginPw("wrongPw")
+                    .build();
+
+            // expect
+            assertThrows(UnauthorizedException.class, () -> authService.login(request));
+        }
+    }
+
+    // === Fixtures ===
+    private MerchantSignUpRequest createSignupRequest() {
+        return MerchantSignUpRequest.builder()
+                .loginId(LOGIN_ID)
+                .loginPw(RAW_PW)
                 .name("가맹점")
                 .businessNumber("123-456")
                 .contactName("홍길동")
                 .contactEmail("email@test.com")
                 .contactPhone("010-1234-5678")
                 .build();
-
-        given(merchantRepository.existsByLoginId("merchant123")).willReturn(false);
-        given(passwordEncoder.encode("pw123")).willReturn("encodedPw");
-        given(merchantRepository.save(any(Merchant.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
-
-        // when
-        MerchantSignUpResponse response = authService.signup(request);
-
-        // then
-        assertEquals("merchant123", response.getLoginId());
-        assertEquals("가맹점", response.getName());
-        assertEquals("ACTIVE", response.getStatus());
     }
 
-    @Test
-    void login_shouldReturnTokens_whenValidCredentials() {
-        // given
-        Merchant merchant = Merchant.builder()
-                .loginId("merchant123")
-                .loginPw("encodedPw")
+    private Merchant createMerchant(String loginId, String encodedPw) {
+        return Merchant.builder()
+                .loginId(loginId)
+                .loginPw(encodedPw)
                 .status("ACTIVE")
                 .build();
-
-        given(merchantRepository.findByLoginId("merchant123"))
-                .willReturn(Optional.of(merchant));
-        given(passwordEncoder.matches("pw123", "encodedPw")).willReturn(true);
-        given(jwtProvider.generateAccessToken("merchant123")).willReturn("access-token");
-        given(jwtProvider.generateRefreshToken("merchant123")).willReturn("refresh-token");
-
-        // when
-        MerchantLoginResponse response = authService.login(
-                MerchantLoginRequest.builder()
-                        .loginId("merchant123")
-                        .loginPw("pw123")
-                        .build()
-        );
-
-        // then
-        assertEquals("access-token", response.getAccessToken());
-        assertEquals("refresh-token", response.getRefreshToken());
     }
 }

--- a/backoffice-manage/src/test/java/com/fastcampus/backofficemanage/service/AuthServiceTokenTest.java
+++ b/backoffice-manage/src/test/java/com/fastcampus/backofficemanage/service/AuthServiceTokenTest.java
@@ -1,0 +1,129 @@
+package com.fastcampus.backofficemanage.service;
+
+import com.fastcampus.backofficemanage.dto.common.CommonResponse;
+import com.fastcampus.backofficemanage.dto.login.response.MerchantLoginResponse;
+import com.fastcampus.backofficemanage.repository.MerchantRepository;
+import com.fastcampus.backofficemanage.security.JwtProvider;
+import com.fastcampus.common.constant.RedisKeys;
+import com.fastcampus.common.exception.code.AuthErrorCode;
+import com.fastcampus.common.exception.exception.UnauthorizedException;
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+@DisplayName("AuthService - Token 관련 테스트")
+class AuthServiceTokenTest {
+
+    @Mock private MerchantRepository merchantRepository;
+    @Mock private BCryptPasswordEncoder passwordEncoder;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks private AuthService authService;
+
+    private AutoCloseable closeable;
+
+    private static final String ACCESS_TOKEN = "abc.def.ghi";
+    private static final String REFRESH_TOKEN = "refresh.token.value";
+    private static final String LOGIN_ID = "merchant123";
+
+    @BeforeEach
+    void setUp() {
+        closeable = openMocks(this);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Nested
+    @DisplayName("로그아웃")
+    class LogoutTest {
+
+        @Test
+        @DisplayName("정상 로그아웃 시 블랙리스트에 저장되고 응답을 반환한다")
+        void givenValidAccessToken_whenLogout_thenBlacklistedAndSuccess() {
+            String bearerToken = "Bearer " + ACCESS_TOKEN;
+            long expiration = 100000L;
+            given(jwtProvider.getRemainingExpiration(ACCESS_TOKEN)).willReturn(expiration);
+
+            ResponseEntity<CommonResponse> response = authService.logout(bearerToken);
+
+            then(redisTemplate.opsForValue()).should().set(
+                    RedisKeys.BLOCKLIST_PREFIX + ACCESS_TOKEN, "logout", expiration, TimeUnit.MILLISECONDS
+            );
+
+            assertTrue(response.getBody().isSuccess());
+            assertEquals("로그아웃 완료", response.getBody().getMessage());
+        }
+
+        @Test
+        @DisplayName("AccessToken이 누락되면 예외를 던진다")
+        void givenEmptyAccessToken_whenLogout_thenThrowsUnauthorized() {
+            UnauthorizedException ex = assertThrows(
+                    UnauthorizedException.class,
+                    () -> authService.logout("")
+            );
+            assertEquals(AuthErrorCode.MISSING_ACCESS_TOKEN, ex.getErrorCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급")
+    class ReissueTest {
+
+        @Test
+        @DisplayName("유효한 RefreshToken이면 새로운 AccessToken을 발급한다")
+        void givenValidRefreshToken_whenReissue_thenReturnsNewAccessToken() {
+            String bearer = "Bearer " + REFRESH_TOKEN;
+            String newAccess = "new.access.token";
+
+            given(jwtProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
+            given(jwtProvider.getSubject(REFRESH_TOKEN)).willReturn(LOGIN_ID);
+            given(jwtProvider.generateAccessToken(LOGIN_ID)).willReturn(newAccess);
+
+            ResponseEntity<MerchantLoginResponse> response = authService.reissue(bearer);
+
+            assertEquals(newAccess, response.getBody().getAccessToken());
+            assertEquals(REFRESH_TOKEN, response.getBody().getRefreshToken());
+        }
+
+        @Test
+        @DisplayName("RefreshToken이 누락되면 예외를 던진다")
+        void givenEmptyRefreshToken_whenReissue_thenThrowsUnauthorized() {
+            UnauthorizedException ex = assertThrows(
+                    UnauthorizedException.class,
+                    () -> authService.reissue("")
+            );
+            assertEquals(AuthErrorCode.MISSING_REFRESH_TOKEN, ex.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("RefreshToken 검증에 실패하면 예외를 던진다")
+        void givenInvalidRefreshToken_whenReissue_thenThrowsUnauthorized() {
+            String bearer = "Bearer invalid.token";
+            String actual = "invalid.token";
+
+            given(jwtProvider.validateToken(actual)).willReturn(false);
+
+            UnauthorizedException ex = assertThrows(
+                    UnauthorizedException.class,
+                    () -> authService.reissue(bearer)
+            );
+            assertEquals(AuthErrorCode.INVALID_REFRESH_TOKEN, ex.getErrorCode());
+        }
+    }
+}

--- a/backoffice-manage/src/test/java/com/fastcampus/backofficemanage/service/MerchantServiceTest.java
+++ b/backoffice-manage/src/test/java/com/fastcampus/backofficemanage/service/MerchantServiceTest.java
@@ -1,0 +1,167 @@
+package com.fastcampus.backofficemanage.service;
+
+import com.fastcampus.backofficemanage.dto.common.CommonResponse;
+import com.fastcampus.backofficemanage.dto.info.MerchantInfoResponse;
+import com.fastcampus.backofficemanage.dto.update.request.MerchantUpdateRequest;
+import com.fastcampus.backofficemanage.entity.Merchant;
+import com.fastcampus.backofficemanage.repository.MerchantRepository;
+import com.fastcampus.common.exception.code.MerchantErrorCode;
+import com.fastcampus.common.exception.exception.DuplicateKeyException;
+import com.fastcampus.common.exception.exception.NotFoundException;
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+@DisplayName("MerchantService 유닛 테스트")
+class MerchantServiceTest {
+
+    @Mock private MerchantRepository merchantRepository;
+    @Mock private Clock clock;
+
+    @InjectMocks private MerchantService merchantService;
+
+    private AutoCloseable closeable;
+    private final static String LOGIN_ID = "merchant123";
+    private final static LocalDateTime NOW = LocalDateTime.of(2025, 5, 20, 12, 0);
+
+    @BeforeEach
+    void setUp() {
+        closeable = openMocks(this);
+        given(clock.instant()).willReturn(NOW.atZone(ZoneId.systemDefault()).toInstant());
+        given(clock.getZone()).willReturn(ZoneId.systemDefault());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Nested
+    @DisplayName("가맹점 정보 조회 (getMyInfo)")
+    class GetMyInfoTests {
+
+        @Test
+        @DisplayName("정상적인 loginId로 조회 시 가맹점 정보 반환")
+        void givenValidLoginId_whenGetMyInfo_thenReturnsInfo() {
+            Merchant merchant = createMerchant();
+            given(merchantRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(merchant));
+
+            MerchantInfoResponse response = merchantService.getMyInfo(LOGIN_ID);
+
+            assertEquals("가맹점", response.getName());
+            assertEquals("123-456", response.getBusinessNumber());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 loginId로 조회 시 NotFoundException 발생")
+        void givenInvalidLoginId_whenGetMyInfo_thenThrows() {
+            given(merchantRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> merchantService.getMyInfo(LOGIN_ID));
+        }
+    }
+
+    @Nested
+    @DisplayName("가맹점 정보 수정 (updateMyInfo)")
+    class UpdateMyInfoTests {
+
+        @Test
+        @DisplayName("정상적으로 수정 요청 시 성공 응답 반환")
+        void givenValidUpdateRequest_whenUpdate_thenSuccessResponse() {
+            Merchant merchant = spy(createMerchant());
+            given(merchantRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(merchant));
+
+            MerchantUpdateRequest request = MerchantUpdateRequest.builder()
+                    .name("변경된이름")
+                    .businessNumber("999-999")
+                    .contactName("이몽룡")
+                    .contactEmail("new@email.com")
+                    .contactPhone("010-9999-8888")
+                    .build();
+
+            CommonResponse response = merchantService.updateMyInfo(LOGIN_ID, request);
+
+            assertTrue(response.isSuccess());
+            assertEquals("가맹점 정보가 성공적으로 수정되었습니다.", response.getMessage());
+            verify(merchant).updateInfo(anyString(), anyString(), anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("수정 시 중복 사업자번호 오류 발생 시 DuplicateKeyException 발생")
+        void givenDuplicateBusinessNumber_whenUpdate_thenThrows() {
+            Merchant merchant = createMerchant();
+            given(merchantRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(merchant));
+            willThrow(DataIntegrityViolationException.class).given(merchantRepository).flush();
+
+            MerchantUpdateRequest request = MerchantUpdateRequest.builder()
+                    .name("변경된이름")
+                    .businessNumber("999-999")
+                    .contactName("이몽룡")
+                    .contactEmail("new@email.com")
+                    .contactPhone("010-9999-8888")
+                    .build();
+
+            assertThrows(DuplicateKeyException.class, () -> merchantService.updateMyInfo(LOGIN_ID, request));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 loginId로 수정 시 NotFoundException 발생")
+        void givenInvalidLoginId_whenUpdate_thenThrows() {
+            given(merchantRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.empty());
+
+            MerchantUpdateRequest request = MerchantUpdateRequest.builder().build();
+            assertThrows(NotFoundException.class, () -> merchantService.updateMyInfo(LOGIN_ID, request));
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴 (deleteMyAccount)")
+    class DeleteMyAccountTests {
+
+        @Test
+        @DisplayName("정상적으로 회원 탈퇴 요청 시 상태값 변경 및 응답 반환")
+        void givenValidLoginId_whenDelete_thenSuccessResponse() {
+            Merchant merchant = createMerchant();
+            given(merchantRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(merchant));
+
+            CommonResponse response = merchantService.deleteMyAccount(LOGIN_ID);
+
+            assertTrue(response.isSuccess());
+            assertEquals("회원 탈퇴가 완료되었습니다.", response.getMessage());
+            assertEquals("DELETED", merchant.getStatus());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 loginId로 탈퇴 요청 시 NotFoundException 발생")
+        void givenInvalidLoginId_whenDelete_thenThrows() {
+            given(merchantRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> merchantService.deleteMyAccount(LOGIN_ID));
+        }
+    }
+
+    // === Fixtures ===
+    private Merchant createMerchant() {
+        return Merchant.builder()
+                .loginId(LOGIN_ID)
+                .loginPw("encodedPw")
+                .name("가맹점")
+                .businessNumber("123-456")
+                .contactName("홍길동")
+                .contactEmail("email@test.com")
+                .contactPhone("010-1234-5678")
+                .status("ACTIVE")
+                .build();
+    }
+}

--- a/common/src/main/java/com/fastcampus/common/util/AppClock.java
+++ b/common/src/main/java/com/fastcampus/common/util/AppClock.java
@@ -1,8 +1,0 @@
-package com.fastcampus.common.util;
-
-import java.time.Clock;
-import java.time.ZoneId;
-
-public class AppClock {
-    public static final Clock CLOCK = Clock.system(ZoneId.of("Asia/Seoul"));
-}


### PR DESCRIPTION
# 요약
> 기존 로그인 코드를 리팩토링했습니다.

# 변경사항
> 비즈니스 로직에서 인증/로깅/예외 공통 처리(AOP)를 분리하여 책임을 분산시켰습니다.
또한 기존의 controller에 있던 비즈니스 로직을 service로 전부 이전시켰고,
외부에서 호출 가능한 주요 비즈니스 메서드는 public으로 노출/내부 로직에서만 사용되는 헬퍼 메서드는 private으로 감춰
캡슐화를 강화함과 동시에 단위 테스트 코드를 추가했습니다.

# 테스트 요소
> 회원가입부터 시작해 모든 service의 단위테스트를 작성하였고, 통합테스트는 금일 진행 예정입니다.
