### PR TITLE
Feat : Entity에 Cardinfo추가 / 결제 빌드 시 생기던 오류 수정

### DIFF
--- a/payment-api/build.gradle.kts
+++ b/payment-api/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     // 모듈 추가
     implementation(project(":common"))
     implementation(project(":payment-core"))
+    implementation(project(":payment-infra"))
 
     // 테스트
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/payment-core/src/main/java/com/fastcampus/paymentcore/core/service/repotestservice.java
+++ b/payment-core/src/main/java/com/fastcampus/paymentcore/core/service/repotestservice.java
@@ -1,7 +1,7 @@
 package com.fastcampus.paymentcore.core.service;
 
 import com.fastcampus.paymentinfra.repository.KeysRepository;
-import com.fastcampus.paymentinfra.entity.Keys;
+import com.fastcampus.paymentinfra.entity.KeysReadOnly;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +13,7 @@ public class repotestservice {
 
     private final KeysRepository keysRepository;
 
-    public Optional<Keys> getKeyByMerchantId(Long merchantId) {
+    public Optional<KeysReadOnly> getKeyByMerchantId(Long merchantId) {
         return keysRepository.findByMerchantId(merchantId);
     }
 }

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/client/MockCardApprovalClient.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/client/MockCardApprovalClient.java
@@ -1,4 +1,4 @@
-package com.fastcampus.paymentinfra.infra.client;
+package com.fastcampus.paymentinfra.client;
 
 public class MockCardApprovalClient {
 }

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/entity/Payment.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/entity/Payment.java
@@ -22,6 +22,10 @@ public class Payment {
     private String paymentStatus;
     private Long paidAmount;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "card_info_id")  // FK 컬럼명. DB에서 이 이름으로 FK 생성됨
+    private CardInfo cardInfo;
+
     @CreationTimestamp
     @Column(columnDefinition = "TIMESTAMP")
     private LocalDateTime approvedAt;

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/repository/KeysRepository.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/repository/KeysRepository.java
@@ -1,11 +1,11 @@
 package com.fastcampus.paymentinfra.repository;
 
-import com.fastcampus.paymentinfra.entity.Keys;
+import com.fastcampus.paymentinfra.entity.KeysReadOnly;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface KeysRepository extends JpaRepository<Keys, Long> {
+public interface KeysRepository extends JpaRepository<KeysReadOnly, Long> {
     // merchantId 기준으로 조회
-    Optional<Keys> findByMerchantId(Long merchantId);
+    Optional<KeysReadOnly> findByMerchantId(Long merchantId);
 }

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/repository/PaymentRepository.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/repository/PaymentRepository.java
@@ -2,6 +2,7 @@ package com.fastcampus.paymentinfra.repository;
 
 import com.fastcampus.paymentinfra.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -11,4 +12,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     List<Payment> findByTransactionId(Long transactionId);
 
     List<Payment> findByPaymentStatus(String paymentStatus);
+
+    @Query("SELECT p FROM Payment p JOIN FETCH p.cardInfo WHERE p.userId = :userId")
+    List<Payment> findByUserIdWithCardInfo(Long userId);
 }


### PR DESCRIPTION
동하 - infra 모듈로부터 Keys entity 삭제 (backoffice 에서 관리) -> 이로 인해 생겼던 사이드이펙트 해결
동하 - infra 모듈 Payment 엔티티에 빠져 있는 칼럼 넣기 (card-info pk 넣기) -> PK로 추가하고,
repository에 fetch join 사용해 n+1 문제 해결 

테스트 : 실제 빌드까지 성공적으로 진행 
