### PR TITLE
Feat: 결제 내역 조회 시 카드 정보도 함께 조회

### DIFF
--- a/backoffice-api/src/main/java/com/fastcampus/backoffice/dto/PaymentDto.java
+++ b/backoffice-api/src/main/java/com/fastcampus/backoffice/dto/PaymentDto.java
@@ -19,4 +19,18 @@ public class PaymentDto {
     private Long lastTransactionId;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    
+    // 카드 정보 필드 추가
+    private CardInfoDto cardInfo;
+    
+    @Getter
+    @Setter
+    public static class CardInfoDto {
+        private Long cardInfoId;
+        private String type;
+        private String last4;
+        private String cardCompany;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
 } 

--- a/backoffice-api/src/main/java/com/fastcampus/backoffice/repository/PaymentRepository.java
+++ b/backoffice-api/src/main/java/com/fastcampus/backoffice/repository/PaymentRepository.java
@@ -13,12 +13,11 @@ import java.util.Optional;
 
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
-    @Query("""
-    SELECT p FROM Payment p
-    WHERE p.merchantId = :merchantId
-      AND p.approvedAt BETWEEN :startDate AND :endDate
-      AND (:status IS NULL OR p.paymentStatus = :status)
-    """)
+    @Query("SELECT p FROM Payment p " +
+           "LEFT JOIN FETCH p.cardInfo " +
+           "WHERE p.merchantId = :merchantId " +
+           "AND (:status IS NULL OR p.paymentStatus = :status) " +
+           "AND p.approvedAt BETWEEN :startDate AND :endDate")
     Page<Payment> findPaymentHistoryWithOptionalStatus(
             @Param("merchantId") Long merchantId,
             @Param("status") String status,
@@ -27,6 +26,9 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
             Pageable pageable
     );
 
-    Optional<Payment> findByTransactionId(Long transactionId);
+    @Query("SELECT p FROM Payment p " +
+           "LEFT JOIN FETCH p.cardInfo " +
+           "WHERE p.transactionId = :transactionId")
+    Optional<Payment> findByTransactionId(@Param("transactionId") Long transactionId);
 }
 

--- a/backoffice-api/src/main/java/com/fastcampus/backoffice/service/PaymentService.java
+++ b/backoffice-api/src/main/java/com/fastcampus/backoffice/service/PaymentService.java
@@ -48,6 +48,19 @@ public class PaymentService {
         dto.setLastTransactionId(payment.getLastTransactionId());
         dto.setCreatedAt(payment.getCreatedAt());
         dto.setUpdatedAt(payment.getUpdatedAt());
+        
+        // 카드 정보 변환
+        if (payment.getCardInfo() != null) {
+            PaymentDto.CardInfoDto cardInfoDto = new PaymentDto.CardInfoDto();
+            cardInfoDto.setCardInfoId(payment.getCardInfo().getCardInfoId());
+            cardInfoDto.setType(payment.getCardInfo().getType());
+            cardInfoDto.setLast4(payment.getCardInfo().getLast4());
+            cardInfoDto.setCardCompany(payment.getCardInfo().getCardCompany());
+            cardInfoDto.setCreatedAt(payment.getCardInfo().getCreatedAt());
+            cardInfoDto.setUpdatedAt(payment.getCardInfo().getUpdatedAt());
+            dto.setCardInfo(cardInfoDto);
+        }
+        
         return dto;
     }
 } 

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/entity/Payment.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/entity/Payment.java
@@ -15,7 +15,11 @@ public class Payment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long paymentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "merchant_id")
     private Long merchantId;//추가
+
     private Long transactionId;
     private Long userId;
     private Long paymentMethod;

--- a/payment-infra/src/main/java/com/fastcampus/paymentinfra/entity/Payment.java
+++ b/payment-infra/src/main/java/com/fastcampus/paymentinfra/entity/Payment.java
@@ -16,9 +16,8 @@ public class Payment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long paymentId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "merchant_id")
-    private Long merchantId;//추가
+    private Long merchantId;
 
     private Long transactionId;
     private Long userId;


### PR DESCRIPTION
# 요약

결제 내역 조회 시 카드 정보도 함께 조회하기
# 변경사항
1. PaymentDto 확장
카드 정보를 포함하는 CardInfoDto 내부 클래스 추가
민감한 정보인 token은 제외하고 필요한 정보만 포함
2. PaymentService 수정
convertToDto 메서드에서 카드 정보도 함께 변환하도록 수정
카드 정보가 없는 경우도 처리
3. PaymentRepository 수정
JPQL 쿼리에 LEFT JOIN FETCH p.cardInfo 추가하여 카드 정보를 함께 조회
N+1 문제 방지를 위한 페치 조인 사용
# 테스트 요소
> 테스트 작성하신 부분에 대해서 어떤 테스트를 진행했는지, 어떻게 요소를 테스트 했는지 설명해주세요.
![image](https://github.com/user-attachments/assets/476bc987-3a29-4ef2-b9f5-fcdfac70ebcb)
